### PR TITLE
feat(list): adds capability to read display column names from config

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,12 @@ Interactive cli-based multi-step form for creating / starting new time entries. 
 
     mite new
 
+Services can be filtered with a whitelist in the configuration file:
+
+    {
+        "whitelistedServices": ["<service name>"]
+    }
+
 ## Open
 
 Opens a specific time entry in your browser

--- a/package-lock.json
+++ b/package-lock.json
@@ -365,8 +365,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
@@ -451,7 +450,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -680,8 +678,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
@@ -2274,8 +2271,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "functional-red-black-tree": {
       "version": "1.0.1",
@@ -2672,7 +2668,6 @@
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
       "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -2885,7 +2880,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -2894,8 +2888,7 @@
     "inherits": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
-      "dev": true
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ini": {
       "version": "1.3.5",
@@ -2967,6 +2960,11 @@
           }
         }
       }
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
     },
     "invariant": {
       "version": "2.2.4",
@@ -3442,7 +3440,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -3809,7 +3806,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -3842,7 +3838,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }
@@ -4031,8 +4027,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -4045,6 +4040,11 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
       "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
     },
     "path-type": {
       "version": "1.1.0",
@@ -4248,6 +4248,14 @@
         }
       }
     },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
@@ -4391,6 +4399,14 @@
       "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
     },
+    "resolve": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.0.tgz",
+      "integrity": "sha512-3sUr9aq5OfSg2S9pNtPA9hL1FVEAjvfOC4leW0SNf/mpnaakz2a9femSd6LqAww2RaFctwyf1lCqnTHuF1rxDg==",
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
     "resolve-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
@@ -4497,6 +4513,16 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -4954,7 +4980,7 @@
     "uri-js": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha1-lMVA4f93KVbiKZUHwBCupsiDjrA=",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
         "punycode": "^2.1.0"
       },
@@ -4962,7 +4988,7 @@
         "punycode": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-          "integrity": "sha1-tYsBCsQMIsVldhbI0sLALHv0eew="
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
         }
       }
     },
@@ -5117,8 +5143,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "0.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3838,7 +3838,7 @@
       "dependencies": {
         "minimist": {
           "version": "0.0.10",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
           "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=",
           "dev": true
         }

--- a/package.json
+++ b/package.json
@@ -61,26 +61,26 @@
     "version": "npm run changelog && git add CHANGELOG.md"
   },
   "dependencies": {
-    "async": "^2.6.2",
+    "async": "^2.6.1",
     "bluebird": "^3.5.3",
-    "chalk": "^2.4.2",
+    "chalk": "^2.4.1",
     "commander": "^2.19.0",
     "csv-string": "^3.1.5",
     "external-editor": "^3.0.3",
-    "inquirer": "^6.2.2",
+    "inquirer": "^6.2.1",
     "markdown-table": "^1.1.2",
     "mite-api": "marcel-devdude/mite-api#master",
     "nconf": "^0.10.0",
     "opn": "^5.4.0",
     "request": "^2.88.0",
     "shelljs": "^0.8.3",
-    "table": "^5.2.3"
+    "table": "^5.1.1"
   },
   "devDependencies": {
     "chai": "^4.2.0",
-    "conventional-changelog-cli": "^2.0.12",
+    "conventional-changelog-cli": "^2.0.11",
     "conventional-recommended-bump": "^4.0.4",
-    "eslint": "^5.13.0",
+    "eslint": "^5.10.0",
     "mocha": "^5.2.0",
     "npm-check": "^5.9.0"
   }

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
     "nconf": "^0.10.0",
     "opn": "^5.4.0",
     "request": "^2.88.0",
+    "shelljs": "^0.8.3",
     "table": "^5.2.3"
   },
   "devDependencies": {

--- a/source/mite-list.js
+++ b/source/mite-list.js
@@ -34,7 +34,9 @@ const GROUP_BY_OPTIONS = [
   'year',
 ];
 
-const COLUMNS_OPTIONS_DEFAULT = 'id,date,user,project,duration,revenue,service,note';
+const COLUMNS_DEFAULT = 'id,date,user,project,duration,revenue,service,note';
+const COLUMNS_CONFIG = config.get().listColumns
+const COLUMNS_OPTIONS_DEFAULT = !!COLUMNS_CONFIG ? COLUMNS_CONFIG : COLUMNS_DEFAULT;
 const COLUMNS_OPTIONS = {
   billable: {
     label: 'billable',

--- a/source/mite-new.js
+++ b/source/mite-new.js
@@ -50,6 +50,9 @@ function getProjectChoices() {
 function getServiceChoices() {
   return bluebird.promisify(mite.getServices)()
     .then(response => response.map(d => d.service))
+    .then(services => config.get().whitelistedServices != null 
+        ? services.filter(service => config.get().whitelistedServices.includes(service.name))
+        : services)
     .then(services => services.map(service => {
       const nameParts = [service.name];
       if (service.billable) {

--- a/source/mite.js
+++ b/source/mite.js
@@ -2,8 +2,26 @@
 'use strict'
 
 const program = require('commander')
+const shell = require('shelljs')
+const path = require('path')
 
 const pkg = require('./../package.json')
+
+const INTERNAL_COMMANDS = [
+  'amend', 'reword', 'config', 'delete', 'rm', 'list', 'ls', 'status', 'st', 'new', 
+  'create', 'open', 'stop', 'start', 'users', 'projects', 'services', 'customers', 'clients',
+  'help', '--help', '-?', '-h'
+];
+
+const mainCommand = path.basename(process.argv[1]);
+const subCommand = process.argv[2];
+const subCommandIsInternal = !!INTERNAL_COMMANDS.find(cmd => cmd === subCommand);
+const couldBeExternalCommand = process.argv.length>2 && !subCommandIsInternal;
+if (couldBeExternalCommand) { 
+    const childCommand = mainCommand + '-' + subCommand;  
+    const childCommandExitCode = shell.exec(childCommand).code;
+    process.exit(childCommandExitCode)
+}
 
 program
   .version(pkg.version)


### PR DESCRIPTION
# Purpose & Description of Change

This change enables a user to control which columns are displayed when executing the `list` sub-command via the config. The feature can be enabled by setting the `listColumns` config property via the `config set` sub-command as exemplified here:

```
$ mite config set listColumns "date,project,service,duration,note" 
```
