### PR TITLE
Added possibility to book times with a single cli call

### DIFF
--- a/source/mite-book.js
+++ b/source/mite-book.js
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+'use strict'
+
+const program = require('commander')
+const miteApi = require('mite-api')
+const bluebird = require('bluebird');
+
+const pkg = require('./../package.json')
+const config = require('./config.js')
+const mite = miteApi(config.get())
+const miteTracker = require('./lib/mite-tracker')(config.get())
+
+program
+  .version(pkg.version)
+  .description('create a new time entry via command line. use <note> with quotation marks.')
+  .arguments('<project> <service> <minutes> <note> [date]')
+  .action((project, service, minutes, note, date) => {
+    main(project, service, minutes, note, date);
+  })
+  .parse(process.argv);
+
+if (process.argv.length < 6 || process.argv.length > 7) {
+  program.help();
+}
+
+function dumpNames(objects, arg, name) {
+ console.log("Found multiple matches for "+name+" <"+arg+">:");
+ console.log("---------------------------------------------------------------");
+ objects.forEach(current => console.log(current.name));
+ console.log("---------------------------------------------------------------");
+ console.log("Please be more precise!\n");
+}
+
+function getProjectChoices(projectArg) {
+  return bluebird.promisify(mite.getProjects)()
+    .then(response => response.map(d => d.project))
+    .then(projects => projects.filter(project => {
+      return (project.name && (project.name.toUpperCase().indexOf(projectArg.toUpperCase()) > -1));
+    }))
+    .then(projects => {
+      if (projects.length > 1) {
+        dumpNames(projects, projectArg, "project");
+      }
+      return projects;
+    });
+}
+
+function getServiceChoices(serviceArg) {
+  return bluebird.promisify(mite.getServices)()
+    .then(response => response.map(d => d.service))
+    .then(services => services.filter(service => {
+      return (service.name && (service.name.toUpperCase().indexOf(serviceArg.toUpperCase()) > -1));
+    }))
+    .then(services => {
+      if (services.length > 1) {
+        dumpNames(services, serviceArg, "service");
+      }
+      return services;
+    });
+}
+
+function main(project, service, minutes, note, date) {
+  return Promise.all([
+    getProjectChoices(project),
+    getServiceChoices(service),
+  ]).then(([projects, services]) => {
+    if (projects.length == 1 && services.length == 1) {
+      let entry = {project_id: projects[0].id, note: note, minutes: minutes, service_id: services[0].id};
+      entry.date_at = date || (new Date()).toISOString().slice(0,10); 
+
+      // http://mite.yo.lk/en/api/time-entries.html#create
+      mite.addTimeEntry({ time_entry: entry }, (response) => {
+        var data = JSON.parse(response);
+        if (data.error) {
+          console.error('Error while creating new time entry:', data.error)
+          process.exit(1)
+          return
+        }
+        const timeEntryId = data.time_entry.id;
+        console.log('Successfully created new time entry (id: %s)', timeEntryId);
+      });
+    } else {
+      process.exit(1)
+      return
+    }
+  }) 
+}

--- a/source/mite-new.js
+++ b/source/mite-new.js
@@ -14,7 +14,7 @@ const miteTracker = require('./lib/mite-tracker')(config.get())
 
 program
   .version(pkg.version)
-  .description('interactively create a new time entry')
+  .description('book a new time entry via command line')
   .arguments('<note>')
   .action((note) => {
     main(note);

--- a/source/mite.js
+++ b/source/mite.js
@@ -18,6 +18,7 @@ program
   .alias('ls')
   .alias('status')
   .alias('st')
+  .command('book', 'create a new time entry from command line parameters')
   .command('new', 'create a new time entry')
   .alias('create')
   .command('open', 'open the given time entry in browser')


### PR DESCRIPTION
# Purpose

With this new function it is possible to create a new mite entry without having to scroll through a list of possibilities. Is is also possible to create aliases to make booking even easier.

Example:

`mite book cool_project internal_service 60 "Enhanced mite-cli"`

Books 60 minutes on cool_project/internal_service with the comment "Enhanced mite-cli"

Using this alias
`alias mite_cool_stuff='mite book cool_project internal_service'`
it is possible to create new entries with the command
`mite_cool_stuff 60 "Enhanced mite-cli"`

As last parameter a date can be given. It is omitted, today is used.

# Description of Change

Created a new function based on the code from mite-new
