### PR TITLE
feat: adds text format

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ Delete a single entry
 
     mite delete 18472721
 
+Deleting a set of entries filtered using `mite list` and unix tools:
+
+    mite list this_month --search="query" --columns id --format=text | xargs -0 mite delete
+
 ## Users
 
 List user accounts while client-side search in name, email & note, sort by email and list only time_trackers and admins. Archived users will be grey.

--- a/source/lib/data-output.js
+++ b/source/lib/data-output.js
@@ -11,6 +11,7 @@ const FORMAT = {
   TSV: 'tsv',
   TABLE: 'table',
   MD: 'md',
+  TEXT: 'text',
 };
 const FORMATS = Object.values(FORMAT);
 
@@ -33,6 +34,9 @@ function formatData(data, format, columns) {
       };
       return table(data, tableConfig);
     }
+    case 'text':
+      // first data item contains the column names
+      return data.splice(1).join("\n");
     case 'tsv':
       return csvString.stringify(data, "\t");
     default:

--- a/source/mite-delete.js
+++ b/source/mite-delete.js
@@ -14,10 +14,15 @@ program
   })
   .arguments('<timeEntryId>')
   .on('--help', function() {
-    console.log();
-    console.log('Examples:');
-    console.log();
-    console.log('  $ mite delete 1283761');
+    console.log(`
+  Examples:
+
+    Delete a single entry identified by it’s id:
+      $ mite delete 1283761
+
+    Delete multiple entries selected by using mite list:
+      $ mite list this_month --search="query" --columns id --format=text | xargs -0 mite delete
+`)
   })
   .action((timeEntryId) => {
     const mite = miteApi(config.get());

--- a/source/mite-list.js
+++ b/source/mite-list.js
@@ -305,6 +305,10 @@ Examples:
 
   create a markdown report of all customer and their generated profits
     $ mite list this_year --format=md --group_by=customer --sort=revenue
+
+  The output of mite list can be forwarded to other commands using xargs. The
+  following example will delete all matchin entries:
+    $ mite list this_month --search="query" --columns id --format=text | xargs -0 mite delete
 `);
   })
   .action(main)


### PR DESCRIPTION
# Purpose

- adds a output format which can be used for:
    - pipe ids to other commands
    - use `xargs` to use other mite cli commands

The following stuff should work:

```
mite list --columns id --format text | xargs -0 echo
```
should echo each id 

# Description of Change

- adds the "text" format which ignores the table headers and outputs the data line by line
- adds example for `xargs` usage to delete multiple entries in README.md, `list` sub-command and ` delete` sub-command