### PR TITLE
feat: amend last & start --last

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Easy to use CLI tool for creating, listing, starting and stopping time tracking 
             - [Advanced Usage](#advanced-usage)
         - [Tracker](#tracker)
             - [Start Tracking](#start-tracking)
+            - [Resume Tracking](#resume-tracking)
             - [Stop Tracking](#stop-tracking)
         - [Modify Time-Entries](#modify-time-entries)
             - [Change Note](#change-note)
@@ -406,6 +407,12 @@ Start tracking of a specific time entry.
 
     mite start <timeEntryId>
 
+#### Resume Tracking
+
+Re-start tracking for the most recent entry
+
+    mite start --last
+
 #### Stop Tracking
 
 Stops any currently running time entry.
@@ -423,6 +430,10 @@ When there’s a tracker running you may want to update the note without opening
 You can also add the `--editor` option so that your favorite editor opens up with the current note. Make sure your `$EDITOR` is correctly set.
 
     mite amend --editor
+
+Change the note for the most recently created entry, f.e. for adding some notes
+
+    mite amend last
 
 You can also alter the notes of other time entries when you specify their id
 

--- a/source/lib/mite-api.js
+++ b/source/lib/mite-api.js
@@ -7,13 +7,35 @@ const miteApi = require('mite-api');
 const { BUDGET_TYPE } = require('./../lib/constants');
 
 /**
+ * @typedef MiteTimeEntryTracker
+ * @type {object}
+ * @property {string} since iso date string of the moment the tracker was
+ *   started
+ * @property {string} minues number of minutes the tracker is running since
+ */
+
+/**
  * @typedef MiteTimeEntry
- * @property {Number} customer_id
- * @property {Number} minutes
- * @property {Number} project_id
- * @property {Number} service_id
- * @property {String} date_at
- * @property {String} note
+ * @type {object}
+ * @property {boolean} billable boolean indicating if this time entry is
+ *   billable or not
+ * @property {number} customer_id id of the customer this entry belongs to
+ * @property {number} id unique id of the entry
+ * @property {boolean} locked indicates wheter the time entry can be edited
+ *   or not
+ * @property {number} minutes number of minutes tracked in this entry
+ * @property {number} project_id id of the project
+ * @property {number} revenue calculated revenue for this time-entry
+ * @property {number} service_id id of the service
+ * @property {number} user_id id of the user
+ * @property {String} customer_name name of customer
+ * @property {String} date_at date string in the format "YYYY-MM-DD"
+ * @property {String} note content
+ * @property {String} project_name project’s name
+ * @property {String} service_name service’s name
+ * @property {MiteTimeEntryTracker} [tracker] information about the currently
+ *   active tracker when this entry is currently tracked
+ * @property {string} user_name name of the user who tracked this entry
  */
 
 /**
@@ -28,7 +50,6 @@ const { BUDGET_TYPE } = require('./../lib/constants');
 class MiteApiWrapper {
 
   /**
-   *
    * @param {MiteConfig} config
    */
   constructor(config) {
@@ -76,7 +97,7 @@ class MiteApiWrapper {
    * current user.
    *
    * @param {Number} limit
-   * @returns {Promise<MiteTimeEntry>}
+   * @returns {Promise<MiteTimeEntry[]>}
    */
   async getMyRecentTimeEntries(limit = 5) {
     assert.strictEqual(typeof limit, 'number', 'expected limit to be number');
@@ -92,6 +113,21 @@ class MiteApiWrapper {
       })
       .then(items => items.map(item => item.time_entry));
   }
+
+  /**
+   * Returns the most recently created time entry of the current user if
+   * there’s one.
+   *
+   * @returns {Promise<MiteTimeEntry[]|false>} most recent time entry or false
+   */
+  async getMyRecentTimeEntry() {
+    return this.getMyRecentTimeEntries(1)
+      .then(entries => {
+        if (entries && entries.length) return entries[0];
+        return false;
+      });
+  }
+
 
   /**
    * Returns an ordered copy of the given items where the given attribute

--- a/source/lib/mite-api.js
+++ b/source/lib/mite-api.js
@@ -4,6 +4,8 @@ const util = require('util');
 const assert = require('assert');
 
 const miteApi = require('mite-api');
+
+const MiteTracker = require('./mite-tracker');
 const { BUDGET_TYPE } = require('./../lib/constants');
 
 /**
@@ -55,6 +57,7 @@ class MiteApiWrapper {
   constructor(config) {
     this.config = config;
     this.mite = miteApi(config);
+    this.tracker = new MiteTracker(config);
   }
 
   /**

--- a/source/mite-start.js
+++ b/source/mite-start.js
@@ -10,16 +10,33 @@ const { handleError, MissingRequiredArgumentError } = require('./lib/errors');
 program
   .version(pkg.version)
   .arguments('[timeEntryId]')
+  .option(
+    '-l, --last',
+    'start the last created entry and continue tracking',
+  )
+  // TODO add examples for "--last"
+  // TODO add examples for amend
   .description('start the tracker for the given id, will also stop allready running entry', {
     timeEntryId: 'id of the entry which should be started'
   });
 
 function main(timeEntryId) {
+  if (String(timeEntryId).toLowerCase()  === 'last') {
+    program.last = true;
+  }
+  // "--last" was used, ignore timeEntryId and use the id of the latest entry
+  // of the current user if there’s one
+  if (program.last) {
+    console.log('find last entry id');
+    process.exit(0);
+  }
+
   if (!timeEntryId) {
     throw new MissingRequiredArgumentError('Missing required argument [timeEntryId]');
   }
   const miteTracker = require('./lib/mite-tracker')(config.get());
   miteTracker.start(timeEntryId)
+    // TODO change output to just the ID when tty is off
     .then(() => console.log(`Successfully started the time entry (id: ${timeEntryId})`))
     .catch(handleError);
 }

--- a/source/mite-start.js
+++ b/source/mite-start.js
@@ -6,7 +6,7 @@ const program = require('commander');
 const pkg = require('./../package.json');
 const config = require('./config');
 const { handleError, MissingRequiredArgumentError } = require('./lib/errors');
-const miteApi = require('./lib/mite-api')(config.get());
+const mite = require('./lib/mite-api')(config.get());
 
 program
   .version(pkg.version)
@@ -36,13 +36,12 @@ async function main(timeEntryId) {
   // "--last" was used, ignore timeEntryId and use the id of the latest entry
   // of the current user if there’s one
   if (program.last) {
-    timeEntryId = (await miteApi.getMyRecentTimeEntry() || {}).id;
+    timeEntryId = (await mite.getMyRecentTimeEntry() || {}).id;
   }
   if (!timeEntryId) {
     throw new MissingRequiredArgumentError('Missing required argument [timeEntryId]');
   }
-  const miteTracker = require('./lib/mite-tracker')(config.get());
-  miteTracker.start(timeEntryId)
+  mite.tracker.start(timeEntryId)
     // TODO change output to just the ID when tty is off
     .then(() => console.log(`Successfully started the time entry (id: ${timeEntryId})`))
     .catch(handleError);


### PR DESCRIPTION
Following the suggestions in #77 this now makes it easier to refer to the most recently created time entry:

`npm start --last` will restart tracking for the most recently created time entry
`npm amend last` will change the note for the most recently created time entry