### PR TITLE
Changed mite domain name to mite.de

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Easy to use CLI tool for creating, listing, starting and stopping time tracking entries in [Mite](https://mite.yo.lk) and much other things using the [mite-api](https://www.npmjs.com/package/mite-api) npm package which is using the [official mite api](https://mite.yo.lk/api/index.html).
+Easy to use CLI tool for creating, listing, starting and stopping time tracking entries in [Mite](https://mite.de) and much other things using the [mite-api](https://www.npmjs.com/package/mite-api) npm package which is using the [official mite api](https://mite.de/api/index.html).
 
 [![MIT License](https://badges.frapsoft.com/os/mit/mit.svg?v=102)](https://github.com/ellerbrock/open-source-badge/)
 [![NPM Package](https://badge.fury.io/js/mite-cli.svg)](https://www.npmjs.com/package/mite-cli)
@@ -93,7 +93,7 @@ _______ _____ _______ _______     _______        _____
 |  |  |   |      |    |______ ___ |       |        |
 |  |  | __|__    |    |______     |_____  |_____ __|__
 
-command line tool for time tracking service mite.yo.lk
+command line tool for time tracking service mite.de
 https://github.com/Ephigenia/mite-cli/
 
 
@@ -155,7 +155,7 @@ Configuration
 ===============================================================================
 
 Before you can start, you’ll need to setup the mite account name ("mycompany" in
-https://**mycompany**.mite.yo.lk) and API key ("Account" -> "My Account").
+https://**mycompany**.mite.de) and API key ("Account" -> "My Account").
 
     mite config set account <name>
     mite config set apiKey <key>
@@ -244,7 +244,7 @@ When an entry is currently active and tracked it will be yellow and indicated wi
 
 #### Filter by time
 
-You also can request longer time frames by using the first argument which is basically the [`at` parameter](https://mite.yo.lk/en/api/time-entries.html#list-all) of the time entries API:
+You also can request longer time frames by using the first argument which is basically the [`at` parameter](https://mite.de/en/api/time-entries.html#list-all) of the time entries API:
 
     mite list this_month
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Ephigenia M. Eichner",
   "name": "mite-cli",
   "version": "1.10.3",
-  "description": "command line tool for time tracking service mite.yo.lk",
+  "description": "command line tool for time tracking service mite.de",
   "preferGlobal": true,
   "homepage": "https://github.com/Ephigenia/mite-cli/",
   "keywords": [

--- a/source/lib/commands/list.js
+++ b/source/lib/commands/list.js
@@ -23,7 +23,7 @@ module.exports.sort = {
 
 module.exports.groupBy = {
   // list of valid options taken from
-  // https://mite.yo.lk/en/api/time-entries.html#list-grouped
+  // https://mite.de/en/api/time-entries.html#list-grouped
   options: [
     'customer',
     'day',

--- a/source/lib/mite-tracker.js
+++ b/source/lib/mite-tracker.js
@@ -8,7 +8,7 @@ class MiteTracker {
   constructor(config) {
     this.config = config;
 
-    this.BASE_URL = `https://${config.account}.mite.yo.lk`;
+    this.BASE_URL = `https://${config.account}.mite.de`;
 
     const headers = {
       'User-Agent': config.applicationName,

--- a/source/mite-customer-new.js
+++ b/source/mite-customer-new.js
@@ -53,7 +53,7 @@ function main(name, opts) {
       process.stdout.write(`Successfully created customer (id: ${customerId}).
 
 Please use web-interface to modify complicated service & hourly rates settings:
-https://${config.get('account')}.mite.yo.lk/customers/${customerId}/edit\n`);
+https://${config.get('account')}.mite.de/customers/${customerId}/edit\n`);
     });
 }
 

--- a/source/mite-open.js
+++ b/source/mite-open.js
@@ -47,7 +47,7 @@ function main(timeEntryId) {
     });
   })
   .then((entry) => {
-    let url = `https://${config.get('account')}.mite.yo.lk/`;
+    let url = `https://${config.get('account')}.mite.de/`;
     process.stdout.write('No time entry id given, opening the organisation’s account\n');
     if (entry) {
       url += 'daily/#' + (entry.date_at).replace('-', '/') + '?open=time_entry_' + entry.id;

--- a/source/mite-project-new.js
+++ b/source/mite-project-new.js
@@ -66,7 +66,7 @@ function main(name, opts) {
       process.stdout.write(`Successfully created project (id: ${projectId}).
 
 Please use web-interface to modify complicated service & hourly rates settings:
-https://${config.get('account')}.mite.yo.lk/reports/projects/${projectId}\n`);
+https://${config.get('account')}.mite.de/reports/projects/${projectId}\n`);
     });
 }
 


### PR DESCRIPTION
# Purpose

I changed the used api domain to the current {accountName}.mite.de. This is just for future-proofing: the legacy schema will continue to work for the foreseeable future.

Background: https://mite.de/en/blog/2023/02/14/upcoming-move-to-mite-de/

